### PR TITLE
Feature/avoid hydras

### DIFF
--- a/cmd/crawler_cmd.go
+++ b/cmd/crawler_cmd.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/cortze/ipfs-cid-hoarder/pkg/config"
+	"github.com/cortze/ipfs-cid-hoarder/pkg/crawler"
+	"github.com/pkg/errors"
+
+	log "github.com/sirupsen/logrus"
+	cli "github.com/urfave/cli/v2"
+)
+
+var CrawlerCmd = &cli.Command{
+	Name:   "crawler",
+	Usage:  "starts simple crawl over the IPFS Network",
+	Action: RunCrawler,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-level",
+			Usage:       "verbosity of the logs that will be displayed [debug,warn,info,error]",
+			EnvVars:     []string{"IPFS_CID_HOARDER_LOGLEVEL"},
+			DefaultText: "info",
+			Value:       config.DefaultConfig.LogLevel,
+		},
+		&cli.StringFlag{
+			Name:        "blacklisting-user-agent",
+			Usage:       "user agent that wants to be blacklisted as fruit of the crawl",
+			EnvVars:     []string{"IPFS_CID_HOARDER_BLOCKLIST_USER_AGENT"},
+			DefaultText: config.DefaultBlacklistUserAgent,
+			Value:       config.DefaultBlacklistUserAgent,
+		},
+	},
+}
+
+func RunCrawler(ctx *cli.Context) error {
+	// here goes all the magic
+
+	// generate config from the urfave/cli context
+	conf, err := config.NewConfig(ctx)
+	if err != nil {
+		return errors.Wrap(err, "unable to generate config from arguments")
+	}
+
+	// set the logs configurations
+	log.SetFormatter(config.ParseLogFormatter("text"))
+	log.SetOutput(config.ParseLogOutput("terminal"))
+	log.SetLevel(config.ParseLogLevel(conf.LogLevel))
+
+	// expose the pprof and prometheus metrics
+	go func() {
+		pprofAddres := config.PprofIp + ":" + config.PprofPort
+		log.Debugf("initializing pprof in %s\n", pprofAddres)
+		err := http.ListenAndServe(pprofAddres, nil)
+		if err != nil {
+			log.Errorf("unable to initialize pprof at %s - error %s", pprofAddres, err.Error())
+		}
+	}()
+
+	var blacklistUserAgent string
+
+	// check if a blacklisting user agent has been submitted
+	if ctx.IsSet("blacklisting-user-agent") {
+		blacklistUserAgent = ctx.String("blacklisting-user-agent")
+	}
+
+	_, err = crawler.RunLightCrawler(ctx.Context, blacklistUserAgent)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -9,13 +9,8 @@ import (
 	"github.com/cortze/ipfs-cid-hoarder/pkg/config"
 	"github.com/cortze/ipfs-cid-hoarder/pkg/hoarder"
 
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
-)
-
-var CmdName = "Run CMD"
-var log = logrus.WithField(
-	"Run Cmd", CmdName,
 )
 
 var RunCmd = &cli.Command{
@@ -117,9 +112,9 @@ func RunHoarder(ctx *cli.Context) error {
 	}
 
 	// set the logs configurations
-	log.Logger.SetFormatter(config.ParseLogFormatter("text"))
-	log.Logger.SetOutput(config.ParseLogOutput("terminal"))
-	log.Logger.SetLevel(config.ParseLogLevel(conf.LogLevel))
+	log.SetFormatter(config.ParseLogFormatter("text"))
+	log.SetOutput(config.ParseLogOutput("terminal"))
+	log.SetLevel(config.ParseLogLevel(conf.LogLevel))
 
 	log.Debug("get configuration:", conf)
 

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -97,6 +97,13 @@ var RunCmd = &cli.Command{
 			DefaultText: "K=20",
 			Value:       config.DefaultConfig.CidNumber,
 		},
+		&cli.BoolFlag{
+			Name:        "hydra-filter",
+			Usage:       "boolean representation to activate or not the filter to avoid connections to hydras",
+			EnvVars:     []string{"IPFS_CID_HOARDER_HYDRA_FILTER"},
+			DefaultText: "false",
+			Value:       config.DefaultConfig.HydraFilter,
+		},
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			cmd.RunCmd,
+			cmd.CrawlerCmd,
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,9 @@ var CliIp string = "0.0.0.0"
 var CliPort string = "9010"
 var UserAgent string = "BSC-Cid-Hoarder"
 
+// Blacklisting UserAgents
+var DefaultBlacklistUserAgent = "hydra-booster"
+
 // default configuration
 var DefaultConfig = Config{
 	LogLevel:       "info",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ var DefaultConfig = Config{
 	ReqInterval:    "30m",
 	StudyDuration:  "48h",
 	K:              20, // K-bucket parameter
+	HydraFilter:    false,
 }
 
 // Config compiles all the set of flags that can be readed from the user while launching the cli
@@ -55,6 +56,7 @@ type Config struct {
 	ReqInterval    string `json:"req-interval"`
 	StudyDuration  string `json:"study-duration"`
 	K              int    `json:"k"`
+	HydraFilter    bool   `json:"hydra-filter"`
 }
 
 // Init takes the command line argumenst from the urfave/cli context and composes the configuration
@@ -80,8 +82,21 @@ func (c *Config) apply(ctx *cli.Context) {
 		if ctx.IsSet("database-endpoint") {
 			c.Database = ctx.String("database-endpoint")
 		}
-		// TODO: Add republish of the records interval
-		// 		 Add the content/peer ping interval
+		if ctx.IsSet("hydra-filter") {
+			c.HydraFilter = ctx.Bool("hydra-filter")
+		}
+		// Time delay between the each of the PRHolder pings
+		if ctx.IsSet("req-interval") {
+			c.ReqInterval = ctx.String("req-interval")
+		}
+		// Set the study duration time
+		if ctx.IsSet("study-duration") {
+			c.StudyDuration = ctx.String("study-duration")
+		}
+		// check the number of random CIDs that we want to generate
+		if ctx.IsSet("k") {
+			c.K = ctx.Int("k")
+		}
 		if ctx.IsSet("cid-source") {
 			c.CidSource = ctx.String("cid-source")
 			// if the TEXT mode was selected, read the file from the cid-file
@@ -98,18 +113,6 @@ func (c *Config) apply(ctx *cli.Context) {
 				// batch of CIDs for the entire study
 				if ctx.IsSet("workers") {
 					c.Workers = ctx.Int("workers")
-				}
-				// Time delay between the each of the PRHolder pings
-				if ctx.IsSet("req-interval") {
-					c.ReqInterval = ctx.String("req-interval")
-				}
-				// Set the study duration time
-				if ctx.IsSet("study-duration") {
-					c.StudyDuration = ctx.String("study-duration")
-				}
-				// check the number of random CIDs that we want to generate
-				if ctx.IsSet("k") {
-					c.K = ctx.Int("k")
 				}
 			case TextFileSource:
 				if ctx.IsSet("cid-file") {

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -1,0 +1,157 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cortze/ipfs-cid-hoarder/pkg/config"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	kdht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p-kad-dht/crawler"
+	tcp "github.com/libp2p/go-tcp-transport"
+
+	ma "github.com/multiformats/go-multiaddr"
+
+	libp2p "github.com/libp2p/go-libp2p"
+)
+
+// Crawler is simply a wrappper on top of the official go-lip2p-kad-dht/crawler
+// It is mainly used to crawl the network searching for Hydra-Booster peers.
+// with the final intention of blacklisting them in the Kad-Dht process if the Avoid-Hydras flags gets triggered
+type Crawler struct {
+	ctx context.Context
+
+	crawler     *crawler.Crawler
+	h           host.Host
+	results     *CrawlResults
+	blacklistUA string
+}
+
+func New(ctx context.Context, privKey crypto.PrivKey, ip, port, blacklistUA string) (*Crawler, error) {
+	log.Debug("generating new crawler for the Cid-Hoarder")
+
+	// compose the multiaddress
+	mAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", ip, port))
+	if err != nil {
+		return nil, err
+	}
+
+	// generate the libp2p host
+	h, err := libp2p.New(
+		libp2p.ListenAddrs(mAddr),
+		libp2p.Identity(privKey),
+		libp2p.UserAgent(config.UserAgent),
+		libp2p.Transport(tcp.NewTCPTransport))
+	if err != nil {
+		return nil, err
+	}
+
+	// create the official crawler
+	c, err := crawler.New(
+		h,
+		crawler.WithParallelism(1000),
+		crawler.WithMsgTimeout(40*time.Second),
+		crawler.WithConnectTimeout(40*time.Second),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Crawler{
+		ctx:         ctx,
+		crawler:     c,
+		h:           h,
+		results:     NewCrawlerResults(),
+		blacklistUA: blacklistUA,
+	}, nil
+}
+
+func RunLightCrawler(ctx context.Context, balcklistingUA string) (CrawlResults, error) {
+	// generate private and public keys for the light crawler
+	priv, _, err := crypto.GenerateKeyPair(crypto.Secp256k1, 256)
+	if err != nil {
+		return CrawlResults{}, errors.Wrap(err, "unable to generate priv key for lighth client")
+	}
+
+	// Initialize the CidHoarder
+	c, err := New(ctx, priv, config.CliIp, config.CliPort, balcklistingUA)
+	if err != nil {
+		return CrawlResults{}, err
+	}
+
+	log.Info("running cid-hoarder crawler")
+
+	results := c.run()
+
+	log.WithFields(log.Fields{
+		"total":       len(results.GetDiscvPeers()),
+		"active":      len(results.GetActivePeers()),
+		"blacklisted": len(results.GetBlacklistedPeers()),
+		"failed":      len(results.GetFailedPeers()),
+		"time":        results.GetCrawlerDuration(),
+	}).Info("crawl summary")
+
+	return *results, nil
+}
+
+func (c *Crawler) run() *CrawlResults {
+	logEntry := log.WithFields(log.Fields{
+		"module": "crawler",
+	})
+
+	// set up the handle Success function for the crawler
+	handleSucc := func(p peer.ID, rtPeers []*peer.AddrInfo) {
+		logEntry.Debugf("peer %s successfully connected", p.String())
+
+		// add the peer `P` to the list of active peers
+		c.results.addPeer(p, active)
+
+		// add each of the `rtPeers` to the discovered peers
+		for _, pi := range rtPeers {
+			c.results.addPeer(pi.ID, disc)
+		}
+
+		// check if the host knows the UserAgent of `P` to see if it matches the blacklisted peers
+		// and add it to the blacklisted peer list
+		ua, err := c.h.Peerstore().Get(p, "AgentVersion")
+		if err == nil && c.blacklistUA != "" { // if there was no error and blacklistUA was defined by user
+			userAgent := ua.(string)
+			if strings.Contains(userAgent, c.blacklistUA) {
+				logEntry.Debugf("peer %s was blacklisted -> useragent %s", p.String(), userAgent)
+				c.results.addPeer(p, blacklist)
+			}
+		}
+	}
+
+	// set up the handle Fail function for the crawler
+	handleFail := func(p peer.ID, err error) {
+		logEntry.Debugf("peer %s wasn't diable", p.String())
+		c.results.addPeer(p, failed)
+	}
+
+	// run the go-libp2p-kad-dht crawler
+	logEntry.Debug("running crawler for the cid-hoarder")
+
+	c.results.initTime = time.Now()
+	c.crawler.Run(c.ctx, kdht.GetDefaultBootstrapPeerAddrInfos(), handleSucc, handleFail)
+	c.results.finishTime = time.Now()
+
+	return c.results
+}
+
+func (c *Crawler) Close() {
+	// check is there is host
+	if c.h == nil {
+		log.Warn("attempting to close non-existing host")
+		return
+	}
+	c.h.Close()
+}

--- a/pkg/crawler/results.go
+++ b/pkg/crawler/results.go
@@ -1,0 +1,127 @@
+package crawler
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+const (
+	disc = iota 	// peer that got discovered but not connected
+	active 			// peer that got successfully connected
+	blacklist		// peer that got connected but belongs to the blacklistable UserAgent List
+	failed
+)
+
+type CrawlResults struct {
+	m sync.RWMutex
+	discPeers map[peer.ID]int
+	initTime time.Time
+	finishTime time.Time
+}
+
+
+func NewCrawlerResults() *CrawlResults{
+	return &CrawlResults {
+		discPeers: make(map[peer.ID]int),
+	}
+}
+
+
+func (r *CrawlResults) addPeer(p peer.ID, status int) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	log.WithFields(log.Fields{
+		"peer": p.String(),
+		"status": status,
+	}).Debug("new peer discovered")
+	
+	// add the peer to the discovered list with the received status
+
+	// if the peer wasn't already in the map, add it straight away
+	s, ok := r.discPeers[p] 
+	if ok {
+		// check previous status
+		switch s {
+		case disc: // if peer was only disc - write straight away
+			r.discPeers[p] = status
+		case active: // if peer was active - only write if blacklistable?
+			if status == blacklist {
+				r.discPeers[p] = status
+			}
+		case blacklist: // if it was blacklisted - do nothing
+		case failed:
+			if status == active || status == blacklist {
+				r.discPeers[p] = status
+			}
+		default: // do nothing?
+		}
+	} else {
+		// add it straight away
+		r.discPeers[p] = status
+	}
+
+}
+
+func (r *CrawlResults) GetDiscvPeers() map[peer.ID]struct{} {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	dicv := make(map[peer.ID]struct{})
+
+	for k, _ := range r.discPeers {
+		dicv[k] = struct{}{}
+	}
+
+	return dicv 
+}
+
+func (r *CrawlResults) GetActivePeers() map[peer.ID]struct{}{
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	atcv := make(map[peer.ID]struct{})
+
+	for k, v := range r.discPeers {
+		if v == active {
+			atcv[k] = struct{}{}
+		}
+	}
+
+	return atcv 
+}
+
+func (r *CrawlResults) GetBlacklistedPeers() map[peer.ID]struct{}{
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	blsp := make(map[peer.ID]struct{})
+
+	for k, v := range r.discPeers {
+		if v == blacklist {
+			blsp[k] = struct{}{}
+		}
+	}
+	return blsp
+}
+
+func (r *CrawlResults) GetFailedPeers() map[peer.ID]struct{}{
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	fail := make(map[peer.ID]struct{})
+
+	for k, v := range r.discPeers {
+		if v == failed {
+			fail[k] = struct{}{}
+		}
+	}
+	return fail
+}
+
+func (c *CrawlResults) GetCrawlerDuration() time.Duration {
+	return c.finishTime.Sub(c.initTime)
+}

--- a/pkg/hoarder/hoarder.go
+++ b/pkg/hoarder/hoarder.go
@@ -55,7 +55,7 @@ func NewCidHoarder(ctx context.Context, conf *config.Config) (*CidHoarder, error
 	}
 
 	// ----- Compose the Libp2p host -----
-	h, err := p2p.NewHost(ctx, priv, config.CliIp, config.CliPort, conf.K)
+	h, err := p2p.NewHost(ctx, priv, config.CliIp, config.CliPort, conf.K, conf.HydraFilter)
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating libp2p host for the tool")
 	}

--- a/pkg/p2p/error_parser.go
+++ b/pkg/p2p/error_parser.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"strings"
 
+	net "github.com/libp2p/go-libp2p-kad-dht/net"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 )
 
@@ -17,6 +18,7 @@ const (
 const (
 	// list errors
 	NoConnError                                         = "none"
+	HydraBoosterError                                   = "hydra_booster"
 	DialErrorIoTimeout                                  = "io_timeout"
 	DialErrorConnectionRefused                          = "connection_refused"
 	DialErrorProtocolNotSupported                       = "protocol_not_supported"
@@ -36,6 +38,7 @@ const (
 )
 
 var KnownErrors = map[string]string{
+	HydraBoosterError:                                   net.HydraPeerError,
 	DialErrorIoTimeout:                                  "i/o timeout",
 	DialErrorConnectionRefused:                          "connection refused",
 	DialErrorProtocolNotSupported:                       "protocol not supported",

--- a/pkg/p2p/error_parser.go
+++ b/pkg/p2p/error_parser.go
@@ -18,7 +18,7 @@ const (
 const (
 	// list errors
 	NoConnError                                         = "none"
-	HydraBoosterError                                   = "hydra_booster"
+	DialBlacklistedPeer                                 = "hydra_booster_peer"
 	DialErrorIoTimeout                                  = "io_timeout"
 	DialErrorConnectionRefused                          = "connection_refused"
 	DialErrorProtocolNotSupported                       = "protocol_not_supported"
@@ -38,7 +38,7 @@ const (
 )
 
 var KnownErrors = map[string]string{
-	HydraBoosterError:                                   net.HydraPeerError,
+	DialBlacklistedPeer:                                  net.ErrBlacklistedPeer.Error(),
 	DialErrorIoTimeout:                                  "i/o timeout",
 	DialErrorConnectionRefused:                          "connection refused",
 	DialErrorProtocolNotSupported:                       "protocol not supported",

--- a/pkg/p2p/host.go
+++ b/pkg/p2p/host.go
@@ -40,7 +40,7 @@ type Host struct {
 	StartTime time.Time
 }
 
-func NewHost(ctx context.Context, privKey crypto.PrivKey, ip, port string, bucketSize int) (*Host, error) {
+func NewHost(ctx context.Context, privKey crypto.PrivKey, ip, port string, bucketSize int, hydraFilter bool) (*Host, error) {
 	log.Debug("generating random cid generator")
 
 	// set the max limit of connections to 30000
@@ -53,7 +53,7 @@ func NewHost(ctx context.Context, privKey crypto.PrivKey, ip, port string, bucke
 	}
 
 	var dht *kaddht.IpfsDHT
-	msgSender := NewCustomMessageSender()
+	msgSender := NewCustomMessageSender(hydraFilter)
 	// generate the libp2p host
 	h, err := libp2p.New(
 		libp2p.ListenAddrs(mAddr),

--- a/pkg/p2p/keys.go
+++ b/pkg/p2p/keys.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
+	log "github.com/sirupsen/logrus"
 )
 
 // Parse a Secp256k1PrivateKey from string, checking if it has the proper curve

--- a/pkg/p2p/messages.go
+++ b/pkg/p2p/messages.go
@@ -13,17 +13,19 @@ import (
 
 // MessageSender handles sending wire protocol messages to a given peer
 type MessageSender struct {
-	m      pb.MessageSender
-	msgNot *Notifier
+	m           pb.MessageSender
+	hydraFilter bool
+	msgNot      *Notifier
 }
 
-func NewCustomMessageSender() *MessageSender {
+func NewCustomMessageSender(hydraFilter bool) *MessageSender {
 	return &MessageSender{
-		msgNot: NewMsgNotifier(),
+		hydraFilter: hydraFilter,
+		msgNot:      NewMsgNotifier(),
 	}
 }
 func (ms *MessageSender) Init(h host.Host, protocols []protocol.ID) pb.MessageSender {
-	msgSender := net.NewMessageSenderImpl(h, protocols)
+	msgSender := net.NewMessageSenderImpl(h, ms.hydraFilter, protocols)
 	ms.m = msgSender
 	return ms
 }

--- a/pkg/p2p/messages.go
+++ b/pkg/p2p/messages.go
@@ -14,18 +14,18 @@ import (
 // MessageSender handles sending wire protocol messages to a given peer
 type MessageSender struct {
 	m           pb.MessageSender
-	hydraFilter bool
+	blacklistedUA string
 	msgNot      *Notifier
 }
 
-func NewCustomMessageSender(hydraFilter bool) *MessageSender {
+func NewCustomMessageSender(blacklistedUA string) *MessageSender {
 	return &MessageSender{
-		hydraFilter: hydraFilter,
+		blacklistedUA: blacklistedUA,
 		msgNot:      NewMsgNotifier(),
 	}
 }
 func (ms *MessageSender) Init(h host.Host, protocols []protocol.ID) pb.MessageSender {
-	msgSender := net.NewMessageSenderImpl(h, ms.hydraFilter, protocols)
+	msgSender := net.NewMessageSenderImpl(h, protocols, ms.blacklistedUA)
 	ms.m = msgSender
 	return ms
 }


### PR DESCRIPTION
## Motivation
This PR sources from the curiosity of knowing what would happened if we didn't have hydras in the IFPS network. Therefore, this PR aims to provide the code-base to measure the PRL in a real scenario where hydras are avoided

## Description
This PR includes all the necessary steps to make hydras disappear from any DHT lookup step while Publishing and Retrieving PRs from the DHT

## Tasks
To complete the PR, I've been summarize the decribed steps in the following tasks:
 [X] The addition of a light crawler to the tool able to generate a list of peers identified by a given `UserAgent`
 [X] Add the light crawler as a separate command in the `ipfs-cid-hoarder` 
 [X] Add the light crawler to the `cid-hoarder` when the `hydra-filter` is raised (to blacklist hydra peers)
 [X] Add the `go-libp2p-kad-dht` [branch](https://github.com/cortze/go-libp2p-kad-dht/pull/1) with the changes into the code