### PR TITLE
Add light live-metrics to the hoarder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # dismiss binaries
 build/
 
-# dismiss data folder including the databases
-data/*
-
 # Dismiss python cached stuff and venv
 __pycache__/
 .ipynb_checkpoints/
@@ -11,10 +8,16 @@ analyzer/.ipynb_checkpoints/
 analyzer/venv/
 logs/
 
-# Ignore the .vscode configuration
+# Exclude debug and complementary files
+.env
+*.sh
+*.txt
+
+# Do not include docker-compose volumes and configurations 
+docker-compose.yml
+ipfs-cid-hoarder/
+
+# Ignore the common IDE configuration files
 .vscode
-#Ignore .idea 
 .idea
 
-# TODO: update to make file and build folder
-dbs

--- a/cmd/crawler_cmd.go
+++ b/cmd/crawler_cmd.go
@@ -53,7 +53,7 @@ func RunCrawler(ctx *cli.Context) error {
 
 	// expose the pprof and prometheus metrics
 	go func() {
-		pprofAddres := config.PprofIp + ":" + config.PprofPort
+		pprofAddres := config.MetricsIp + ":" + config.MetricsPort
 		log.Debugf("initializing pprof in %s\n", pprofAddres)
 		err := http.ListenAndServe(pprofAddres, nil)
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,14 +10,16 @@ var log = logrus.WithField(
 )
 
 // Harcoded variables for the tool's profiling
-var PprofIp = "127.0.0.1"
-var PprofPort = "9020"
+var MetricsIp = "127.0.0.1"
+var MetricsPort = "9022"
 var DefaultBlacklistUserAgent = ""
 var DefaultDHTProvideOperation = "standard"
 
 // default configuration
 var DefaultConfig = Config{
 	Port:             "9010",
+	MetricsIP:        MetricsIp,
+	MetricsPort:      MetricsPort,
 	LogLevel:         "info",
 	Database:         "postgres://user:password@ip:port/db",
 	CidContentSize:   1024, // 1MB in KBs
@@ -34,6 +36,8 @@ var DefaultConfig = Config{
 // Config compiles all the set of flags that can be read by the user while launching the cli
 type Config struct {
 	Port             string `json:"port"`
+	MetricsIP        string `json:"metrics-ip"`
+	MetricsPort      string `json:"metrics-port"`
 	LogLevel         string `json:"log-level"`
 	Database         string `json:"database-endpoint"`
 	CidContentSize   int    `json:"cid-content-size"`
@@ -61,6 +65,10 @@ func (c *Config) Apply(ctx *cli.Context) {
 	if ctx.Command.Name == "run" {
 		if ctx.IsSet("port") {
 			c.Port = ctx.String("port")
+		}
+
+		if ctx.IsSet("metrics-port") {
+			c.MetricsPort = ctx.String("metrics-port")
 		}
 
 		if ctx.IsSet("log-level") {

--- a/pkg/hoarder/cid_set.go
+++ b/pkg/hoarder/cid_set.go
@@ -3,6 +3,7 @@ package hoarder
 import (
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/cortze/ipfs-cid-hoarder/pkg/models"
 )
@@ -140,4 +141,19 @@ func (s *cidSet) Len() int {
 	defer s.RUnlock()
 
 	return len(s.cidArray)
+}
+
+func (s *cidSet) NextValidTimeToPing() (time.Time, bool) {
+	var validTime time.Time
+	s.RLock()
+	defer s.RUnlock()
+	for _, cid := range s.cidArray {
+		nextping := cid.NextPing
+		// asume that the array is sorted
+		if validTime.IsZero() && !nextping.IsZero() {
+			validTime = nextping
+			return validTime, true
+		}
+	}
+	return validTime, false
 }

--- a/pkg/hoarder/hoarder_metrics.go
+++ b/pkg/hoarder/hoarder_metrics.go
@@ -1,0 +1,157 @@
+package hoarder
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cortze/ipfs-cid-hoarder/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	hoarderModeName   = "hoarder"
+	hoarderModDetails = "general metrics about the hoarder"
+
+	// List of metrics that we are going to export
+	ongoingCids = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: hoarderModeName,
+		Name:      "ongoing_cids",
+		Help:      "Number of cids that are currently published and being tracked",
+	})
+	secsToNextPing = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: hoarderModeName,
+		Name:      "secs_to_next_ping",
+		Help:      "Number of seconds left to ping the next cid",
+	})
+	totalPublishedCids = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: hoarderModeName,
+		Name:      "total_publish_cids",
+		Help:      "Total number of cids that have been published since the launch of the hoarder",
+	},
+		[]string{"provide_op"},
+	)
+	pingingCidsPerHost = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: hoarderModeName,
+		Name:      "pinging_cids_per_host",
+		Help:      "Number of cids that each of the libp2p host is concurrently tracking",
+	},
+		[]string{"host_id"},
+	)
+)
+
+func (h *CidHoarder) GetMetrics() *metrics.MetricsModule {
+	// create a new prometheus metrics module
+	metricsMod := metrics.NewMetricsModule(
+		hoarderModeName,
+		hoarderModDetails)
+
+	// add all the smaller metrics
+	metricsMod.AddIndvMetric(
+		h.ongoingCidMetrics(),
+		h.secsToNextPingMetrics(),
+		h.totalPublishedCidsMetrics(),
+		h.pingingCidsperHostMetrics())
+	return metricsMod
+}
+
+func (h *CidHoarder) ongoingCidMetrics() *metrics.IndvMetrics {
+	initFn := func() error {
+		prometheus.MustRegister(ongoingCids)
+		return nil
+	}
+	updateFn := func() (interface{}, error) {
+		cids := h.cidSet.Len()
+		ongoingCids.Set(float64(cids))
+		return cids, nil
+	}
+
+	indvMetrics, err := metrics.NewIndvMetrics(
+		"ongoing_cids",
+		initFn,
+		updateFn)
+	if err != nil {
+		log.WithField("mod", "hoarder-metrics").Error(err)
+		return nil
+	}
+	return indvMetrics
+}
+
+func (h *CidHoarder) secsToNextPingMetrics() *metrics.IndvMetrics {
+	initFn := func() error {
+		prometheus.MustRegister(secsToNextPing)
+		return nil
+	}
+	updateFn := func() (interface{}, error) {
+		validTime, valid := h.cidSet.NextValidTimeToPing()
+		if !valid {
+			log.WithField("mod", "hoarder-metrics").Warnf(
+				fmt.Sprintf("no valid time for next ping [time: %s]", validTime))
+		}
+		validSecs := validTime.Sub(time.Now()).Seconds()
+		ongoingCids.Set(float64(validSecs))
+		return validSecs, nil
+	}
+
+	indvMetrics, err := metrics.NewIndvMetrics(
+		"secs_to_next_ping",
+		initFn,
+		updateFn)
+	if err != nil {
+		log.WithField("mod", "hoarder-metrics").Error(err)
+		return nil
+	}
+	return indvMetrics
+}
+
+func (h *CidHoarder) totalPublishedCidsMetrics() *metrics.IndvMetrics {
+	initFn := func() error {
+		prometheus.MustRegister(totalPublishedCids)
+		return nil
+	}
+	updateFn := func() (interface{}, error) {
+		totalCids := h.cidPublisher.GetTotalPublishedCids()
+		for op, val := range totalCids {
+			totalPublishedCids.WithLabelValues(op).Set(float64(val))
+		}
+		return totalCids, nil
+	}
+
+	indvMetrics, err := metrics.NewIndvMetrics(
+		"total_publish_cids",
+		initFn,
+		updateFn)
+	if err != nil {
+		log.WithField("mod", "hoarder-metrics").Error(err)
+		return nil
+	}
+	return indvMetrics
+}
+
+func (h *CidHoarder) pingingCidsperHostMetrics() *metrics.IndvMetrics {
+	initFn := func() error {
+		prometheus.MustRegister(pingingCidsPerHost)
+		return nil
+	}
+	updateFn := func() (interface{}, error) {
+		hostWorkload := h.cidPinger.GetHostWorkload()
+		total := 0
+		for host, cids := range hostWorkload {
+			pingingCidsPerHost.WithLabelValues(fmt.Sprintf("%d", host)).Set(float64(cids))
+			total = total + cids
+		}
+		pingingCidsPerHost.WithLabelValues("total").Set(float64(total))
+		hostWorkload[-1] = total
+		return hostWorkload, nil
+	}
+
+	indvMetrics, err := metrics.NewIndvMetrics(
+		"pinging_cids_per_host",
+		initFn,
+		updateFn)
+	if err != nil {
+		log.WithField("mod", "hoarder-metrics").Error(err)
+		return nil
+	}
+	return indvMetrics
+}

--- a/pkg/hoarder/pinger.go
+++ b/pkg/hoarder/pinger.go
@@ -324,6 +324,10 @@ func (pinger *CidPinger) runPinger(pingerID int, closeC chan struct{}) {
 	}
 }
 
+func (pinger *CidPinger) GetHostWorkload() map[int]int {
+	return pinger.hostPool.GetHostWorkload()
+}
+
 func (pinger *CidPinger) Close() {
 	log.WithField("mod", "pinger").Info("shutdown detected from the CidPinger")
 	pinger.orchersterCloseC <- struct{}{}

--- a/pkg/metrics/module.go
+++ b/pkg/metrics/module.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type MetricsModule struct {
+	name    string // name the defines the exporter (Example Peer-Prometheus-Exporter)
+	details string
+
+	IndvMetrics []*IndvMetrics
+}
+
+func NewMetricsModule(
+	name string,
+	details string) *MetricsModule {
+
+	module := &MetricsModule{
+		name:    name,
+		details: details,
+	}
+	return module
+}
+
+func (m *MetricsModule) AddIndvMetric(indvMetric ...*IndvMetrics) error {
+	m.IndvMetrics = append(m.IndvMetrics, indvMetric...)
+	return nil
+}
+
+func (m *MetricsModule) Init() error {
+	for _, metric := range m.IndvMetrics {
+		err := metric.Init()
+		if err != nil {
+			return errors.Wrap(err, "error registering metric "+metric.Name())
+		}
+	}
+	return nil
+}
+
+func (m *MetricsModule) UpdateSummary() map[string]interface{} {
+	summary := make(map[string]interface{}, 0)
+	// iter over indvModules
+	for _, metric := range m.IndvMetrics {
+		// add metric status to summary
+		indvSum, err := metric.UpdateMetrics()
+		if err != nil {
+			log.Error("unable update metrics for indv metric " + metric.Name())
+		}
+		summary[metric.Name()] = indvSum
+	}
+	return summary
+}
+
+func (m *MetricsModule) Name() string {
+	return m.name
+}
+
+func (m *MetricsModule) Details() string {
+	return m.details
+}
+
+type IndvMetrics struct {
+	name     string                      // name the defines the exporter (Example Peer-Prometheus-Exporter)
+	initFn   func() error                // Initialization of the exporter
+	updateFn func() (interface{}, error) // function that will be executed in the running loop (the func needs to run a go routine)
+}
+
+// NewIndvMetrics
+func NewIndvMetrics(
+	name string,
+	initFn func() error,
+	updateFn func() (interface{}, error)) (*IndvMetrics, error) {
+
+	// check if all the necesaty parameters where given
+	if len(name) <= 0 {
+		return nil, errors.New("no name was provided" + name)
+	}
+
+	module := &IndvMetrics{
+		name:     name,
+		initFn:   initFn,
+		updateFn: updateFn,
+	}
+	return module, nil
+}
+
+func (m *IndvMetrics) Init() error {
+	// Init loop for each of the Exporters
+	log.Infof("init %s metrics", m.name)
+	return m.initFn()
+}
+
+func (m *IndvMetrics) UpdateMetrics() (interface{}, error) {
+	// generate the ticker for the periodic metrics export
+	return m.updateFn()
+}
+
+func (m *IndvMetrics) Name() string {
+	return m.name
+}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	EndpointUrl string = "metrics"
+
+	MetricLoopInterval time.Duration = 15 * time.Second // Default Prometheus Frequency
+)
+
+type PrometheusMetrics struct {
+	ctx context.Context
+
+	ExposedIp       string
+	ExposedPort     string
+	EndpointUrl     string
+	RefreshInterval time.Duration
+
+	Modules []*MetricsModule
+
+	wg     sync.WaitGroup
+	closeC chan struct{}
+}
+
+func NewPrometheusMetrics(ctx context.Context, ip, port string) *PrometheusMetrics {
+	return &PrometheusMetrics{
+		ctx:             ctx,
+		ExposedIp:       ip,
+		ExposedPort:     port,
+		EndpointUrl:     EndpointUrl,
+		RefreshInterval: MetricLoopInterval,
+		Modules:         make([]*MetricsModule, 0),
+		closeC:          make(chan struct{}),
+	}
+}
+
+func (p *PrometheusMetrics) AddMeticsModule(newMod ...*MetricsModule) {
+	p.Modules = append(p.Modules, newMod...)
+}
+
+func (p *PrometheusMetrics) Start() error {
+	http.Handle("/"+p.EndpointUrl, promhttp.Handler())
+	go func() {
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%s", p.ExposedIp, p.ExposedPort), nil))
+	}()
+
+	err := p.initPrometheusMetrics()
+	if err != nil {
+		return errors.Wrap(err, "unable to init prometheus metrics")
+	}
+
+	p.wg.Add(1)
+	go p.launchMetricsUpdater()
+
+	return nil
+}
+
+func (p *PrometheusMetrics) initPrometheusMetrics() error {
+	log.Debugf("initializing %d metrics modules", len(p.Modules))
+	// iter through all the available modules - and call the
+	// mudule.InitMetrics() method
+	for _, mod := range p.Modules {
+		err := mod.Init()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *PrometheusMetrics) launchMetricsUpdater() {
+	defer p.wg.Done()
+	ticker := time.NewTicker(p.RefreshInterval)
+	for {
+		select {
+		case <-ticker.C:
+			log.Trace("updating values for prometheus metrics")
+			// update all the submodules on prometheus
+			for _, mod := range p.Modules {
+				summary := make(map[string]interface{}, 0)
+				modSum := mod.UpdateSummary()
+				for key, value := range modSum {
+					summary[key] = value
+				}
+				// compose a message with the give summary
+				logFields := log.Fields(modSum)
+				log.WithFields(logFields).Infof("summary for %s", mod.Name())
+			}
+
+		case <-p.closeC:
+			log.Debug("detected a controled shutdown")
+			return
+		case <-p.ctx.Done():
+			log.Debug("detected that context died, shutting down")
+			return
+		}
+	}
+}
+
+func (p *PrometheusMetrics) Close() {
+	// Init loop for each of the Exporters
+	log.Debugf("closing %d prometheus metrics modules", len(p.Modules))
+	p.closeC <- struct{}{}
+	p.wg.Wait()
+	log.Debug("prometheus metrics exporte successfully closed")
+}


### PR DESCRIPTION
# Motivation
With the recent upgrade of the hoarder to support long-running studies and the support of multiple pinger hosts (host-pool), getting more insights about what is happening inside the hoarder is crucial to help us debug any possible bug. Thus, this PR aims to create a standard Prometheus service that gathers metrics about the main components and exposes it together with the `Go` and `libp2p` ones on `http://<metrics_ip>:<metrics_port>/metrics`

# Description
The PR includes
- Main Prometheus exporter service
- Logic of metrics modules and metrics
- Aggregation of the primary metrics from the hoarder like:
    - total published CIDs
    - number of seconds to the next cid ping
    - total workload and sub-division per DHT host
    - number of CIDs that are getting tracked
    
# Status
Results of `http://localhost:9022/metrics`: 
```
# HELP hoarder_ongoing_cids Number of cids that are currently published and being tracked
# TYPE hoarder_ongoing_cids gauge
hoarder_ongoing_cids 5.940842559
# HELP hoarder_pinging_cids_per_host Number of cids that each of the libp2p host is concurrently tracking
# TYPE hoarder_pinging_cids_per_host gauge
hoarder_pinging_cids_per_host{host_id="0"} 9
hoarder_pinging_cids_per_host{host_id="1"} 3
hoarder_pinging_cids_per_host{host_id="total"} 12
# HELP hoarder_secs_to_next_ping Number of seconds left to ping the next cid
# TYPE hoarder_secs_to_next_ping gauge
hoarder_secs_to_next_ping 0
# HELP hoarder_total_publish_cids Total number of cids that have been published since the launch of the hoarder
# TYPE hoarder_total_publish_cids gauge
hoarder_total_publish_cids{provide_op="std-dht-provide"} 10
```

Console logs:
```
INFO[0031] summary for hoarder                           ongoing_cids=6 pinging_cids_per_host="map[-1:0 0:0 1:0]" secs_to_next_ping=31.022068888 total_publish_cids="map[std-dht-provide:5]"
```



