### PR TITLE
Update host wb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,15 @@ require (
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/libp2p/go-libp2p-kad-dht v0.23.0
+	github.com/libp2p/go-libp2p-xor v0.1.0
 	github.com/multiformats/go-multiaddr v0.9.0
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.15.1
 	github.com/sirupsen/logrus v1.9.2
 	github.com/urfave/cli/v2 v2.25.3
+	go.uber.org/atomic v1.11.0
+	golang.org/x/sync v0.2.0
 )
 
 require (
@@ -62,7 +66,6 @@ require (
 	github.com/libp2p/go-libp2p-asn-util v0.3.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
-	github.com/libp2p/go-libp2p-xor v0.1.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect
@@ -89,14 +92,13 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
-	github.com/prometheus/client_golang v1.15.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
 	github.com/quic-go/qtls-go1-20 v0.2.2 // indirect
-	github.com/quic-go/quic-go v0.34.0 // indirect
+	github.com/quic-go/quic-go v0.33.0 // indirect
 	github.com/quic-go/webtransport-go v0.5.3 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -106,7 +108,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel v1.15.1 // indirect
 	go.opentelemetry.io/otel/trace v1.15.1 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.17.0 // indirect
 	go.uber.org/fx v1.19.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -115,7 +116,6 @@ require (
 	golang.org/x/exp v0.0.0-20230519143937-03e91628a987 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,8 @@ github.com/quic-go/qtls-go1-19 v0.3.2 h1:tFxjCFcTQzK+oMxG6Zcvp4Dq8dx4yD3dDiIiyc8
 github.com/quic-go/qtls-go1-19 v0.3.2/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
 github.com/quic-go/qtls-go1-20 v0.2.2 h1:WLOPx6OY/hxtTxKV1Zrq20FtXtDEkeY00CGQm8GEa3E=
 github.com/quic-go/qtls-go1-20 v0.2.2/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
-github.com/quic-go/quic-go v0.34.0 h1:OvOJ9LFjTySgwOTYUZmNoq0FzVicP8YujpV0kB7m2lU=
-github.com/quic-go/quic-go v0.34.0/go.mod h1:+4CVgVppm0FNjpG3UcX8Joi/frKOH7/ciD5yGcwOO1g=
+github.com/quic-go/quic-go v0.33.0 h1:ItNoTDN/Fm/zBlq769lLJc8ECe9gYaW40veHCCco7y0=
+github.com/quic-go/quic-go v0.33.0/go.mod h1:YMuhaAV9/jIu0XclDXwZPAsP/2Kgr5yMYhe9oxhhOFA=
 github.com/quic-go/webtransport-go v0.5.3 h1:5XMlzemqB4qmOlgIus5zB45AcZ2kCgCy2EptUrfOPWU=
 github.com/quic-go/webtransport-go v0.5.3/go.mod h1:OhmmgJIzTTqXK5xvtuX0oBpLV2GkLWNDA+UeTGJXErU=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=

--- a/pkg/hoarder/pinger.go
+++ b/pkg/hoarder/pinger.go
@@ -186,6 +186,8 @@ func (pinger *CidPinger) runPingOrchester() {
 						cidInfo.StudyDuration,
 						pinger.cidS.Len())
 				}
+				// Add Cid to the host to have an effective WB
+				h.AddCidPing(cidInfo)
 				pinger.pingTaskC <- pingTask{h, cidInfo}
 
 			} else {
@@ -226,8 +228,10 @@ func (pinger *CidPinger) runPinger(pingerID int, closeC chan struct{}) {
 		}
 		select {
 		case pingT := <-pinger.pingTaskC:
+
 			var wg sync.WaitGroup
 
+			
 			cidStr := pingT.CID.Hash().B58String()
 			pingCounter := pingT.GetPingCounter()
 			plog.Infof("pinging CID %s for round %d with host %d", cidStr, pingCounter, pingT.host.GetHostID())
@@ -239,8 +243,6 @@ func (pinger *CidPinger) runPinger(pingerID int, closeC chan struct{}) {
 				pingCounter,
 				pingT.K,
 			)
-			// Add Cid to the host
-			pingT.host.AddCidPing(pingT.CidInfo)
 
 			pingCtx, cancel := context.WithTimeout(pinger.ctx, pinger.taskTimeout)
 			defer cancel()

--- a/pkg/p2p/dht_host.go
+++ b/pkg/p2p/dht_host.go
@@ -244,6 +244,7 @@ func (h *DHTHost) GetOngoingCidPings() int {
 	return len(h.ongoingPings)
 }
 
+// Deprecater so far
 func (h *DHTHost) XORDistanceToOngoingCids(cidHash cid.Cid) (*big.Int, bool) {
 	cidK := key.BytesKey([]byte(cidHash.Hash()))
 	xorDist := big.NewInt(0)

--- a/pkg/p2p/host_pool.go
+++ b/pkg/p2p/host_pool.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"sort"
 	"sync"
 
@@ -79,6 +78,9 @@ func (p *HostPool) OneMoreHost(hOpts DHTHostOptions) error {
 }
 
 func (p *HostPool) GetBestHost(newCid *models.CidInfo) (*DHTHost, error) {
+	// Previus method that balances the pings based on XOR distance 
+	// Deprecated as it is not 100% tested 
+	/*
 	p.m.RLock()
 	xorDists := make([]*big.Int, len(p.hostArray))
 	for idx, dhtHost := range p.hostArray {
@@ -106,7 +108,12 @@ func (p *HostPool) GetBestHost(newCid *models.CidInfo) (*DHTHost, error) {
 		// return at least the first node in the list (is among the hosts with fewer ongoing cids)
 		return p.hostArray[hid], ErrorRetrievingBestHost
 	}
-	return p.hostArray[hid], nil
+	*/
+	if p.Len() <= 0 {
+		return nil, errors.New("trying to get host from a pool with 0 hosts")
+	}
+	p.SortHost()
+	return p.hostArray[0], nil
 }
 
 func (p *HostPool) GetHostWorkload() map[int]int {


### PR DESCRIPTION
Following the main idea of having multiple DHT hosts to improve the concurrency performance in the tool, this PR simplifies the XOR distance method to elect the best host, as it isn't 100% ready. The new method selects the host with fewer concurrent ongoing calls as the best one.

The PR also aims to reduce the extra Memory overhead that pprof points to `quic-go`  
![pprof002](https://github.com/cortze/ipfs-cid-hoarder/assets/45786396/32bd4ca4-8de5-45a7-a782-a5f8fd531dd2)

and that has been already brought up by https://github.com/quic-go/quic-go/issues/3883 . As suggested in the issue, The PR rolls back the `quic-go` version to it's `0.33.0` version. 
