### PR TITLE
limit Libp2p host to use only TCP 

### DIFF
--- a/pkg/p2p/dht_host.go
+++ b/pkg/p2p/dht_host.go
@@ -21,6 +21,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	ma "github.com/multiformats/go-multiaddr"
@@ -104,6 +105,7 @@ func NewDHTHost(ctx context.Context, opts DHTHostOptions) (*DHTHost, error) {
 		libp2p.Identity(privKey),
 		libp2p.UserAgent(DefaultUserAgent),
 		libp2p.ResourceManager(rm),
+		libp2p.Transport(tcp.TcpTransport{}),
 		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
 			var err error
 			dhtOpts := make([]kaddht.Option, 0)

--- a/pkg/p2p/dht_host.go
+++ b/pkg/p2p/dht_host.go
@@ -105,7 +105,7 @@ func NewDHTHost(ctx context.Context, opts DHTHostOptions) (*DHTHost, error) {
 		libp2p.Identity(privKey),
 		libp2p.UserAgent(DefaultUserAgent),
 		libp2p.ResourceManager(rm),
-		libp2p.Transport(tcp.TcpTransport{}),
+		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
 			var err error
 			dhtOpts := make([]kaddht.Option, 0)

--- a/pkg/p2p/host_pool.go
+++ b/pkg/p2p/host_pool.go
@@ -78,36 +78,36 @@ func (p *HostPool) OneMoreHost(hOpts DHTHostOptions) error {
 }
 
 func (p *HostPool) GetBestHost(newCid *models.CidInfo) (*DHTHost, error) {
-	// Previus method that balances the pings based on XOR distance 
-	// Deprecated as it is not 100% tested 
+	// Previus method that balances the pings based on XOR distance
+	// Deprecated as it is not 100% tested
 	/*
-	p.m.RLock()
-	xorDists := make([]*big.Int, len(p.hostArray))
-	for idx, dhtHost := range p.hostArray {
-		xorDist, idle := dhtHost.XORDistanceToOngoingCids(newCid.CID)
-		if idle { // if any host is idle, return it directly
-			return dhtHost, nil
+		p.m.RLock()
+		xorDists := make([]*big.Int, len(p.hostArray))
+		for idx, dhtHost := range p.hostArray {
+			xorDist, idle := dhtHost.XORDistanceToOngoingCids(newCid.CID)
+			if idle { // if any host is idle, return it directly
+				return dhtHost, nil
+			}
+			xorDists[idx] = xorDist
 		}
-		xorDists[idx] = xorDist
-	}
-	p.m.RUnlock()
+		p.m.RUnlock()
 
-	// get max dist out of the closes ongoing one
-	var hid int
-	maxDist := big.NewInt(0)
-	for idx, xorDist := range xorDists {
-		i := maxDist.Cmp(xorDist)
-		if i == int(big.Below) {
-			maxDist = xorDist
-			hid = idx
+		// get max dist out of the closes ongoing one
+		var hid int
+		maxDist := big.NewInt(0)
+		for idx, xorDist := range xorDists {
+			i := maxDist.Cmp(xorDist)
+			if i == int(big.Below) {
+				maxDist = xorDist
+				hid = idx
+			}
 		}
-	}
-	p.m.RLock()
-	defer p.m.RUnlock()
-	if hid == 0 && maxDist == big.NewInt(0) {
-		// return at least the first node in the list (is among the hosts with fewer ongoing cids)
-		return p.hostArray[hid], ErrorRetrievingBestHost
-	}
+		p.m.RLock()
+		defer p.m.RUnlock()
+		if hid == 0 && maxDist == big.NewInt(0) {
+			// return at least the first node in the list (is among the hosts with fewer ongoing cids)
+			return p.hostArray[hid], ErrorRetrievingBestHost
+		}
 	*/
 	if p.Len() <= 0 {
 		return nil, errors.New("trying to get host from a pool with 0 hosts")


### PR DESCRIPTION
# Motivation
As asked in the [Filecoin slack channel](https://filecoinproject.slack.com/archives/C03K82MU486/p1686246739580479), the  `quic`  transport seems to be too Memory consuming for a multiple host instance. After some testing using only TPC as the primary transport protocol for the 3 concurrent hosts that the hoarder spawns, the memory reduction over time (even when the hoarder is at 100% workload) is more than considerable.

the `heap memory` reported by the tool goes stable at 2.6GB - 3GB (with 6k CIDs), while previously, it would keep increasing up to 15GB (with only 1k CIDs).  

Thus, this PR sets TCP as only and single transport protocol until the Quic behaviour is inspected 

